### PR TITLE
homebrew formulae is named 'openstackclient' not 'python-openstackclient'

### DIFF
--- a/PlusDemonstrator/GettingStarted.MD
+++ b/PlusDemonstrator/GettingStarted.MD
@@ -101,7 +101,7 @@ zypper install python-PROJECTclient
 ### MacOS
 
 ```console
-brew install python-openstackclient
+brew install openstackclient
 ```
 
 ### PIP


### PR DESCRIPTION


Signed-off-by: Felix Kronlage-Dammers <fkr@hazardous.org>