### PR TITLE
Docs on integrating alertmanager with existing on-call infrastructure

### DIFF
--- a/Operational-Docs/integrating-alertmanager.md
+++ b/Operational-Docs/integrating-alertmanager.md
@@ -35,3 +35,19 @@ receivers:
           - id: <opsgenie-responder-id>
             type: team
 ```
+
+## Matrix
+
+To integrate with the [matrix](https://matrix.org/) protocol a bot that is able to receive webhooks such as 
+[alertmanager\_matrix](https://github.com/dkess/alertmanager_matrix) or 
+[matrix-alertmanager](https://github.com/jaywink/matrix-alertmanager) can be used.
+This example serves as a reference for any kind of system that works via webhooks.
+Within alertmanager a webhook is set as the receiver:
+
+```
+receivers:
+- name: 'matrix'
+  webhook_configs:
+    - url: <webhook-of-matrix-bot>
+```
+

--- a/Operational-Docs/integrating-alertmanager.md
+++ b/Operational-Docs/integrating-alertmanager.md
@@ -1,0 +1,37 @@
+# Integrating Alertmanager
+
+SCS integrates [alertmanager](https://github.com/prometheus/alertmanager) as part of the
+monitoring stack. In order to integrate alertmanager with existing on-call infrastructure
+configurations can be deployed via the overlays.
+The overlays can be deployed from the manager node. Overlays are placed in:
+
+`/opt/configuration/environments/kolla/files/overlays`
+
+Examples of integrations can be found (and added) to this document.
+
+
+## Opsgenie
+
+To integrate with [Opsgenie](https://www.atlassian.com/software/opsgenie) the following snippet
+can be used:
+
+```
+---
+global:
+  resolve_timeout: 5m
+  opsgenie_api_key: <opsgenie-api-key>
+
+route:
+  receiver: opsgenie
+  group_by: [alertname, datacenter, app]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: opsgenie
+    opsgenie_configs:
+      - responders:
+          - id: <opsgenie-responder-id>
+            type: team
+```


### PR DESCRIPTION
Provide a set of best-practices on howto integrate alertmanager with existing on-call infrastructure