### PR TITLE
Rename hw/nestvirt support from -vmx to -hwv.

### DIFF
--- a/Design-Docs/flavor-naming.md
+++ b/Design-Docs/flavor-naming.md
@@ -50,7 +50,7 @@ We believe the following characteristics are important in a flavour description:
 
 | Prefix | CPU | Suffix     | RAM[GiB] | optional: Disk[GB] | optional: Disk type | optional: extra features                           |
 |--------|-----|------------|----------|--------------------|---------------------|----------------------------------------------------|
-| SCS-   |  N  | L/V/T/C[i] | :N[u][o] | [:[Mx]N]           | [n/s/l/p]           | [-hyp][-vmx][-[arch[N][h][-[G/g]X[N][:M[h]]][-ib] |
+| SCS-   |  N  | L/V/T/C[i] | :N[u][o] | [:[Mx]N]           | [n/s/l/p]           | [-hyp][-hwv][-[arch[N][h][-[G/g]X[N][:M[h]]][-ib] |
 
 (Note that `N` and `M` are placeholders for numbers here).
 
@@ -201,22 +201,24 @@ or Bare Metal Systems should indicate the Hypervisor according to the following 
 - SCS-2C:4:10n-**bms**
 - SCS-2C:4:10n-**bms**-z3h
 
-## [OPTIONAL] Nested virtualization
+## [OPTIONAL] Hardware virtualization / Nested virtualization
 
-If you support nested virtualization, i.e. your hypervisor exposes the (on x86)
-VMX CPU flag to its guests and does the necessary fault handling and emulation
-to make it look like you have hardware virtualization support in your guest,
-this can be reflected with a `-vmx` flag (after the optional Hypervisor).
-Flavors without the `-vmx` flag may or may not support nested virtualization (as we
+If the instances that are created with this flavor support hardware-accelerated
+virtualization, this can be reflected with the `-hwv` flag (after the optional
+Hypervisor flag). On x86, this means that in the instance, the CPU flag vmx (intel)
+or svm (AMD) is available. This will be the case on Bare Metal flavors on almost 
+all non-ancient x86 CPUs or if your virtualization hypervisor is configured to
+support nested virtualization.
+Flavors without the `-hwv` flag may or may not support hardware virtualization (as we
 recommend enabling nesting, but don't require flavor names to reflect all
 capabilities. Flavors may overdeliver ...)
 
 **Examples**
 
 - SCS-2C:4:10           <- may or may not support HW virtualization in VMs
-- SCS-2C:4:10-kvm-**vmx**
-- SCS-2C:4:10-**vmx** 	<- not recommended, but allowed
-- ~~SCS-2C:4:10-**vmx**-xen~~ 	<- illegal, wrong ordering
+- SCS-2C:4:10-kvm-**hwv**
+- SCS-2C:4:10-**hwv** 	<- not recommended, but allowed
+- ~~SCS-2C:4:10-**hwv**-xen~~ 	<- illegal, wrong ordering
 
 ## [OPTIONAL] CPU Architecture Details
 

--- a/Design-Docs/tools/flavor-name-check.py
+++ b/Design-Docs/tools/flavor-name-check.py
@@ -9,7 +9,7 @@
 # 10-19: Error in CPU:Ram spec
 # 20-29: Error in Disk spec
 # 30-39: Error in Hype spec
-# 40-49: Error in optional -vmx support
+# 40-49: Error in optional -hwv support
 # 50-59: Error in optional specific CPU description
 # 60-69: Error in optional GPU spec
 # 70-79: Unknown extension
@@ -371,13 +371,13 @@ class Hype(Prop):
     outstr = "%s"
     tbl_hype = {"kvm": "KVM", "xen": "Xen", "hyv": "Hyper-V", "vmw": "VMware", "bms": "Bare Metal System"}
 
-class NestVirt(Prop):
-    type = "NestedVirtualization"
-    parsestr = re.compile(r"\-(vmx)")
-    pattrs = ("nestvirt",)
-    pnames = ("?NestedVirt",)
-    outstr = "%?vmx"
-    #tbl_hype = {"vmx": "HW virtualization (nested)"}
+class HWVirt(Prop):
+    type = "Hardware/NestedVirtualization"
+    parsestr = re.compile(r"\-(hwv)")
+    pattrs = ("hwvirt",)
+    pnames = ("?HardwareVirt",)
+    outstr = "%?hwv"
+    #tbl_hype = {"hwv": "HW virtualization (nested)"}
 
 class CPUBrand(Prop):
     type = "CPUBrand"
@@ -415,14 +415,14 @@ class IB(Prop):
     pnames = ("?IB",)
     outstr = "%?ib"
 
-def outname(cpuram, disk, hype, nvirt, cpubrand, gpu, ib):
+def outname(cpuram, disk, hype, hvirt, cpubrand, gpu, ib):
         out = "SCS-" + cpuram.out()
         if disk.parsed:
             out += ":" + disk.out()
         if hype.parsed:
             out += "-" + hype.out()
-        if nvirt.parsed:
-            out += "-" + nvirt.out()
+        if hvirt.parsed:
+            out += "-" + hvirt.out()
         if cpubrand.parsed:
             out += "-" + cpubrand.out()
         if gpu.parsed:
@@ -453,8 +453,8 @@ def parsename(nm):
     n = n[disk.parsed:]
     hype = Hype(n)
     n = n[hype.parsed:]
-    nvirt = NestVirt(n)
-    n = n[nvirt.parsed:]
+    hvirt = HWVirt(n)
+    n = n[hvirt.parsed:]
     # FIXME: Need to ensure we don't misparse -ib here
     cpubrand = CPUBrand(n)
     n = n[cpubrand.parsed:]
@@ -463,20 +463,20 @@ def parsename(nm):
     ib = IB(n)
     n = n[ib.parsed:]
     if verbose:
-        printflavor(nm, (cpuram, disk, hype, nvirt, cpubrand, gpu, ib))
+        printflavor(nm, (cpuram, disk, hype, hvirt, cpubrand, gpu, ib))
 
     if n:
         print("ERROR: Could not parse: %s" % n)
         raise NameError("Error 70: Could not parse %s (extras?)" % n)
 
     errbase = 0
-    for el in (cpuram, disk, hype, nvirt, cpubrand, gpu, ib):
+    for el in (cpuram, disk, hype, hvirt, cpubrand, gpu, ib):
         errbase += 10
         err = el.validate()
         if err:
             raise NameError("Validation error %i (in el %i (%s) in %s)" % (err+errbase, err-1, el.pnames[err-1], el.type))
 
-    return (cpuram, disk, hype, nvirt, cpubrand, gpu, ib)
+    return (cpuram, disk, hype, hvirt, cpubrand, gpu, ib)
 
 def inputflavor():
     cpuram = Main("")
@@ -485,15 +485,15 @@ def inputflavor():
     disk.input()
     hype = Hype("")
     hype.input()
-    nvirt = NestVirt("")
-    nvirt.input()
+    hvirt = HWVirt("")
+    hvirt.input()
     cpubrand = CPUBrand("")
     cpubrand.input()
     gpu = GPU("")
     gpu.input()
     ib = IB("")
     ib.input()
-    return (cpuram, disk, hype, nvirt, cpubrand, gpu, ib)
+    return (cpuram, disk, hype, hvirt, cpubrand, gpu, ib)
 
 
 def main(argv):


### PR DESCRIPTION
vmx is actually an intel specific name; it's called svm on AMD. (Good catch from Mathias, thanks!)

So chose a name that is neutral -- not only for x86-64, but even for arm and others: hwv is short for hardware virtualization.

Signed-off-by: Kurt Garloff <kurt@garloff.de>