### PR TITLE
Img Metadata Spec is effective Oct 31.

### DIFF
--- a/Design-Docs/Image-Properties-Spec.md
+++ b/Design-Docs/Image-Properties-Spec.md
@@ -2,6 +2,7 @@
 title: SCS Image Metadata Proposal
 version: 2022-09-15-001
 authors: Kurt Garloff, Christian Berendt, Felix Kronlage-Dammers, Mathias Fechner, Ralf Heiringhoff
+effective-date: 2022-10-31
 state: Released (v1.0)
 ---
 


### PR DESCRIPTION
This means that after that date, conformance tests must pass.

Signed-off-by: Kurt Garloff <kurt@garloff.de>