### PR TITLE
Add a "Related Documents" optional section to consider.

### DIFF
--- a/Standards/scs-0001-v1-sovereign-cloud-standards.md
+++ b/Standards/scs-0001-v1-sovereign-cloud-standards.md
@@ -108,6 +108,8 @@ In addition, the following OPTIONAL sections should be considered:
   detailing any open discussion points with respect to a document.
   This section is RECOMMENDED during the discussion phase (pre 1.0.0)
   as a "table of contents" of things to work on in that context.
+- A *Related Documents* section which references related Standards
+  or Decisions, both upstream and/or other SCS documents.
 
 # Process
 


### PR DESCRIPTION
We should often have standards / decision records that relate to other SCS or upstream standards. So suggest to consider it.

Signed-off-by: Kurt Garloff <kurt@garloff.de>