### PR TITLE
Fix minor issues in contribute docs

### DIFF
--- a/community/contribute/adding-docs-guide.md
+++ b/community/contribute/adding-docs-guide.md
@@ -10,20 +10,20 @@ Determine the type of your documentation and click to continue.
 2. [Operational documentation](#2-operational-documentation)
 3. [Community documentation](#3-community-documentation)
 
-If unsure don't hestitate to ask us at [Matrix](/community/communication/matrix.md)
+If unsure don't hestitate to ask us at [Matrix](/community/communication/matrix.md).
 
 ## 1. Technical Documentation
 
 ### Step 1 – Checklist
 
-Your repository containing the documentation has to be:
+Your repository containing the documentation has to...
 
-- a public repository
+- be a public repository
 - contain a directory named `/doc` or `/docs` within root, containing the documentation files
 
-The documentation files have to be in markdown format and:
+The documentation files have to be in markdown format and...
 
-- comply [SCS licensing guidelines](../git◊hub/dco-and-licenses.md)
+- comply with [SCS licensing guidelines](../github/dco-and-licenses.md)
 - match our
   - [markdown file structure guideline](../contribute/doc-files-structure-guide-md)
   - linting Rules
@@ -33,24 +33,24 @@ The documentation files have to be in markdown format and:
 
 File a Pull Request within the [docs-page](https://github.com/SovereignCloudStack/docs-page) repository and add your repo to the docs.package.json:
 
-```json
+```json5
 [
     {
-        "repo": "demo-organisation/demo-repository",
         // link to github organisation and repository 
-        "source": "doc/*.md",
+        "repo": "demo-organisation/demo-repository",
         // directory which shall be copied. Optional to specify only copying markdown files
-        "target": "docs",
+        "source": "doc/*.md",
         // directory where the files should be copied to within the docs-page repo
-        "label": "demo-repository-label"
+        "target": "docs",
         // label for directory. only mandatory if source file is set to copy only *.md files and not the complete directory
+        "label": "demo-repository-label"
     }
 ]
 ```
 
-Once it is approved and merged, a postinstall script will be triggered within the build process. This initiates downloading, copy and distilling which results in this static generated [documentation](https://docs.scs.community) page – now with your content.
+Once it is approved and merged, a postinstall script will be triggered within the build process. This initiates downloading, copying and distilling which results in this static generated [documentation](https://docs.scs.community) page – now with your content.
 
-An explanation on how the sync & distill workflow and a guide on how to test it in a local development environment you will find [here](../contribute/docs-workflow-explanation.md).
+An explanation on how the sync & distill workflow works and a guide on how to test it in a local development environment you will find [here](../contribute/docs-workflow-explanation.md).
 
 ## 2. Operational documentation
 

--- a/community/contribute/docs-workflow-explanation.md
+++ b/community/contribute/docs-workflow-explanation.md
@@ -8,9 +8,9 @@ The aim within this documentation is to have a good developer experience and a l
 
 * Docs that explain, guide or contextualize specific modules such as the openstack-image-manager or the k8s-cluster-api-provider reside within their repository in a seperate docs directory.
 
-Both, the general docs and docs of the external repositories are combined into the one  unified documentation collection that is being rendered in a static page on <https://docs.scs.community>. In order to make this work we have developed a workflow that syncs all doc repositories and distills only the relevant markdown files.
+Both, the general docs and docs of the external repositories are combined into the one unified documentation collection that is being rendered in a static page on <https://docs.scs.community>. In order to make this work we have developed a workflow that syncs all doc repositories and distills only the relevant markdown files.
 
-The script is called `getDocs` a postinstall script and executed after `npm install`. This has the advantage to have the docs – coming from the cloud – in your local docusaurus development environment aswell as in the build process.
+The script is called `getDocs`. It is a postinstall script and is executed after `npm install`. This has the advantage to have the docs – coming from the cloud – in your local docusaurus development environment as well as in the build process.
 
 You'll find the script in the root directory of the [SovereignCloudStack/docs-page](https://github.com/SovereignCloudStack/docs-page) repository:
 


### PR DESCRIPTION
Just minor things I'd consider to adjust. All in all, after reading this document, that I feel like I do understand how the mechanism works, so thanks for sharing!

---

Regarding the changes to the inline JSON:

1. As plain JSON does not support comments (but this example of course benefits from comments), using `json5` as format of the code block results in a nicer visual rendering - even though it will not be valid plain JSON either way.
2. I'd usually expect comments to be above the thing that they are commenting on - not below.
3. (not touched by this PR:) The comments could be maybe a bit more precise regarding the type of data which is to be expected.
    - `link to github organisation and repository` has `demo-organisation/demo-repository` as example, which is not a link per se.
    - `directory which shall be copied. Optional to specify only copying markdown files` has `doc/*.md` as example, which is not a directory, but a glob which can expand to `n` files, which is probably what `Optional to specify only copying markdown files` says, but I did not get that first try.
    - `label for directory. only mandatory if source file is set to copy only *.md files and not the complete directory` kind of clarifies the previous point: It can be set to a directory as well as to a glob matching individual files.
