### PR TITLE
Update .markdownlint-cli2.jsonc

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -2,7 +2,7 @@
   "config": {
     "default": true,
     "MD013": false,
-    "MD033": true,
+    "MD033": { "allowed_elements": ["input"] }, // only allowing input elements within md tables
     "MD024": false,
     "search-replace": {
       "rules": [


### PR DESCRIPTION
* allow for inline-html but only `<input>` for allowing checkboxes within tables see, [here](https://github.com/SovereignCloudStack/docs/pull/34)