### PR TITLE
fix link to documentation about the identity federation concept in SCS

### DIFF
--- a/dev-docs/operations/iam/identity-federation-in-scs.md
+++ b/dev-docs/operations/iam/identity-federation-in-scs.md
@@ -18,8 +18,7 @@ The following sections describe how this is done.
 ## 1. IaaS / OpenStack
 
 To provide Infrastrucure as a Service SCS builds upon
-OpenStack. See the `openstack-federation-via-oidc` document
-in [the iam section of this documentation](https://docs-staging.scs.community/docs/iam/)
+OpenStack. See section [OpenStack Federation via OpenID-Connect](https://docs-staging.scs.community/dev-docs/operations/iam/openstack-federation-via-oidc)
 for more details on identity federation for OpenStack.
 
 ## 2. CaaS

--- a/dev-docs/operations/iam/identity-federation-in-scs.md
+++ b/dev-docs/operations/iam/identity-federation-in-scs.md
@@ -18,7 +18,7 @@ The following sections describe how this is done.
 ## 1. IaaS / OpenStack
 
 To provide Infrastrucure as a Service SCS builds upon
-OpenStack. See section [OpenStack Federation via OpenID-Connect](https://docs-staging.scs.community/dev-docs/operations/iam/openstack-federation-via-oidc)
+OpenStack. See section [OpenStack Federation via OpenID-Connect](https://docs.scs.community/dev-docs/operations/iam/openstack-federation-via-oidc)
 for more details on identity federation for OpenStack.
 
 ## 2. CaaS


### PR DESCRIPTION
During the initial commit for https://github.com/SovereignCloudStack/docs/pull/72 the final location of the documents was unkown and then it was merged into a dev-docs folder, so now the link points to an entirely unintended section of the SCS documentation, making it inaccessible and adding to confusion rather than fulfilling its original intention.