### PR TITLE
Fix build and make it less brittle (hopefully)

### DIFF
--- a/docs.package.json
+++ b/docs.package.json
@@ -7,13 +7,7 @@
   },
   {
     "repo": "osism/osism.github.io",
-    "source": "docs/guides/operations-guide/openstack/image-manager.md",
-    "target": "docs/02-iaas/components",
-    "label": ""
-  },
-  {
-    "repo": "osism/osism.github.io",
-    "source": "docs/guides/operations-guide/openstack/flavor-manager.md",
+    "source": "docs/guides/operations-guide/openstack/*",
     "target": "docs/02-iaas/components",
     "label": ""
   },

--- a/docs.package.json
+++ b/docs.package.json
@@ -7,7 +7,7 @@
   },
   {
     "repo": "osism/osism.github.io",
-    "source": "docs/guides/operations-guide/openstack/*",
+    "source": "docs/guides/operations-guide/openstack/day2-operations/*",
     "target": "docs/02-iaas/components",
     "label": ""
   },


### PR DESCRIPTION
The image manager docs now need additional files, which haven't been copied in the build process.

Resolves #120 