### PR TITLE
Add reports section to the Zuul user guide

### DIFF
--- a/contributor-docs/operations/operations/zuul-ci-cd-quickstart-user-guide.md
+++ b/contributor-docs/operations/operations/zuul-ci-cd-quickstart-user-guide.md
@@ -168,6 +168,27 @@ Pipelines available in SCS Zuul:
 
 If you want to know more about pipelines: [See official documentation](https://zuul-ci.org/docs/zuul/latest/config/pipeline.html)
 
+### Reports
+
+The SCS Zuul instance can transmit build reports through an MQTT connection
+to the dedicated Matrix chat room `SCS | Zuul Reports`. Currently, this MQTT reporting
+feature is activated for periodic pipelines (periodic-hourly, periodic-daily,
+compliance_check), and reports are dispatched solely in the event of
+failures occurring in builds triggered by the mentioned pipelines.
+
+See an example pipeline that reports failed result to the `SCS | Zuul Reports` Matrix room:
+
+```yaml
+- pipeline:
+    name: pipeline-that-reports-to-matrix
+    description: |
+      In the event of a failure, this pipeline transmits reports to
+      the SCS | Zuul Reports Matrix chat room.
+    failure:
+      mqtt:
+        topic: "zuul/{pipeline}/{project}/{branch}/{change}"
+```
+
 ### Jobs
 
 All jobs that your Zuul instances knows of can be used for your own purposes.

--- a/contributor-docs/operations/operations/zuul-ci-cd-quickstart-user-guide.md
+++ b/contributor-docs/operations/operations/zuul-ci-cd-quickstart-user-guide.md
@@ -189,6 +189,9 @@ See an example pipeline that reports failed result to the `SCS | Zuul Reports` M
         topic: "zuul/{pipeline}/{project}/{branch}/{change}"
 ```
 
+Visit the [official Zuul documentation](https://zuul-ci.org/docs/zuul/latest/config/pipeline.html#reporters)
+and explore the configuration options available for Zuul's reporters.
+
 ### Jobs
 
 All jobs that your Zuul instances knows of can be used for your own purposes.


### PR DESCRIPTION
This PR notifies SCS Zuul users about the activation of reporting to the Matrix chat room `SCS | Zuul Reports` for periodic pipelines (periodic-hourly, periodic-daily, compliance_check). Additionally, it includes an example demonstrating how to configure MQTT reporting in the pipeline.