### PR TITLE
Add openstack project for e2e tests for kaas v1

### DIFF
--- a/community/cloud-resources/cloud-resources.md
+++ b/community/cloud-resources/cloud-resources.md
@@ -67,7 +67,7 @@ Service users will have their default_project_id set to a specific project and w
 | b682eb90fb834278afb1182018dd2133 | p500924-scoopex             | scoopex           | Marc's gx-scs project                 | ∞            |
 | 021af0688c594bf88ed675b942d3bea8 | p500924-gx-cred-generator   | anjastrunk        | SCS Gaia-X Self-Description Generator | ∞            |
 | a07c811315ad40f585945b2939ef12dd | p500924-scs-zuul            | o-otte            | SCS Zuul                              | 30.11.2024   |
-| 1846709967a744b69f9eb48cac89bb04 | p500924-gxhackathon6-1      | chess-knight      | Gaia-X Hackathon 6 Projekt1           | ∞            |
+| 1846709967a744b69f9eb48cac89bb04 | p500924-scs-k8s-e2e         | chess-knight      | E2E-Test for KaaS                     | ∞            |
 |                                  |                             |                   |                                       |              |
 
 ## Wavecon

--- a/community/cloud-resources/cloud-resources.md
+++ b/community/cloud-resources/cloud-resources.md
@@ -67,6 +67,7 @@ Service users will have their default_project_id set to a specific project and w
 | b682eb90fb834278afb1182018dd2133 | p500924-scoopex             | scoopex           | Marc's gx-scs project                 | ∞            |
 | 021af0688c594bf88ed675b942d3bea8 | p500924-gx-cred-generator   | anjastrunk        | SCS Gaia-X Self-Description Generator | ∞            |
 | a07c811315ad40f585945b2939ef12dd | p500924-scs-zuul            | o-otte            | SCS Zuul                              | 30.11.2024   |
+| 1846709967a744b69f9eb48cac89bb04 | p500924-gxhackathon6-1      | chess-knight      | Gaia-X Hackathon 6 Projekt1           | ∞            |
 |                                  |                             |                   |                                       |              |
 
 ## Wavecon


### PR DESCRIPTION
For E2E tests for KaaS v1 we reuse project **p500924-gxhackathon6-1**(it was not deleted in #31 and was not created in #42).

I put myself as a *Community Contact* and changed *Needed until* ∞ for this project.

Can you also change the project name and description there?
E.g.(according to #42):
- *Project Name*: from **p500924-gxhackathon6-1** to **scs-k8s-e2e**
- *Description*: from **Gaia-X Hackathon 6 Projekt1** to **E2E-Test for KaaS**

Related to SovereignCloudStack/issues#516