### PR TITLE
Add container registry docs and display it on the overview map

### DIFF
--- a/docs.package.json
+++ b/docs.package.json
@@ -25,10 +25,7 @@
   },
   {
     "repo": "SovereignCloudStack/standards",
-    "source": [
-      "Standards/*.md",
-      "Tests/scs-*.yaml"
-    ],
+    "source": ["Standards/*.md", "Tests/scs-*.yaml"],
     "target": "standards",
     "label": ""
   },
@@ -37,5 +34,11 @@
     "source": "docs/guides",
     "target": "docs/02-iaas/",
     "label": ""
+  },
+  {
+    "repo": "SovereignCloudStack/k8s-harbor",
+    "source": "docs",
+    "target": "docs/03-container/components",
+    "label": "container-registry"
   }
 ]

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -254,6 +254,23 @@ const sidebarsDocs = {
                   ]
                 }
               ]
+            },
+            {
+              type: 'category',
+              label: 'Container Registry',
+              link: {
+                type: 'generated-index'
+              },
+              items: [
+                'container/components/container-registry/docs/quickstart',
+                'container/components/container-registry/docs/scs-deployment',
+                'container/components/container-registry/docs/rate_limit',
+                'container/components/container-registry/docs/upgrade',
+                'container/components/container-registry/docs/backup_and_restore',
+                'container/components/container-registry/docs/migration',
+                'container/components/container-registry/docs/persistence',
+                'container/components/container-registry/docs/ha-deployment'
+              ]
             }
           ]
         }

--- a/static/data/architecturalOverviewData.json
+++ b/static/data/architecturalOverviewData.json
@@ -33,6 +33,12 @@
           "url": "/docs/container",
           "mandatory": "false",
           "stable": "false"
+        },
+        {
+          "title": "Container Registry",
+          "url": "/docs/category/container-registry",
+          "mandatory": "false",
+          "stable": "true"
         }
       ]
     }


### PR DESCRIPTION
This PR adds container registry docs and display container registry on the overview map

Related to https://github.com/SovereignCloudStack/docs/issues/136