### PR TITLE
Add monitoring docs and display it on the overview map

### DIFF
--- a/docs.package.json
+++ b/docs.package.json
@@ -40,5 +40,11 @@
     "source": "docs",
     "target": "docs/03-container/components",
     "label": "container-registry"
+  },
+  {
+    "repo": "SovereignCloudStack/k8s-observability",
+    "source": "docs",
+    "target": "docs/04-operating-scs/components",
+    "label": "monitoring"
   }
 ]

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -303,6 +303,26 @@ const sidebarsDocs = {
                 'operating-scs/components/status-page/docs/components',
                 'operating-scs/components/status-page/docs/levels_of_consensus'
               ]
+            },
+            {
+              type: 'category',
+              label: 'Monitoring',
+              link: {
+                type: 'generated-index'
+              },
+              items: [
+                'operating-scs/components/monitoring/docs/overview',
+                'operating-scs/components/monitoring/docs/quickstart',
+                'operating-scs/components/monitoring/docs/scs-deployment',
+                'operating-scs/components/monitoring/docs/infrastructure_services',
+                'operating-scs/components/monitoring/docs/iaas',
+                'operating-scs/components/monitoring/docs/kaas',
+                'operating-scs/components/monitoring/docs/zuul',
+                'operating-scs/components/monitoring/docs/alertmanager',
+                'operating-scs/components/monitoring/docs/oauth',
+                'operating-scs/components/monitoring/docs/tracing',
+                'operating-scs/components/monitoring/docs/tuning'
+              ]
             }
           ]
         },

--- a/static/data/architecturalOverviewData.json
+++ b/static/data/architecturalOverviewData.json
@@ -11,6 +11,12 @@
           "url": "/docs/operating-scs/components/status-page/docs/overview",
           "mandatory": "true",
           "stable": "true"
+        },
+        {
+          "title": "Monitoring",
+          "url": "/docs/category/monitoring",
+          "mandatory": "false",
+          "stable": "true"
         }
       ]
     }


### PR DESCRIPTION
This PR adds monitoring docs and displays the monitoring on the overview map

Related to https://github.com/SovereignCloudStack/docs/issues/136

@maxwolfs 
The monitoring box does not fit the Ops Layer box on the overview map, see here:
 
![image](https://github.com/SovereignCloudStack/docs/assets/17620218/204460ea-fc6f-4703-acec-840e4c7e986e)

What are your preferences here? i.e.: resize the ops layer box only or resize the entire component map?...  