### PR TITLE
Add cluster-stacks' (KaaS V2) component CSPO docs and display it on the overview map

### DIFF
--- a/docs.package.json
+++ b/docs.package.json
@@ -18,6 +18,12 @@
     "label": "k8s-cluster-api-provider"
   },
   {
+    "repo": "SovereignCloudStack/cluster-stack-provider-openstack",
+    "source": "docs",
+    "target": "docs/03-container/components/cluster-stacks/components",
+    "label": "cluster-stack-provider-openstack"
+  },
+  {
     "repo": "SovereignCloudStack/status-page-openapi",
     "source": "docs",
     "target": "docs/04-operating-scs/components",

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -257,6 +257,25 @@ const sidebarsDocs = {
             },
             {
               type: 'category',
+              label: 'Cluster Stacks',
+              link: {
+                type: 'generated-index'
+              },
+              items: [
+                {
+                  type: 'category',
+                  label: 'Cluster Stack Provider OpenStack',
+                  items: [
+                    'container/components/cluster-stacks/components/cluster-stack-provider-openstack/docs/overview',
+                    'container/components/cluster-stacks/components/cluster-stack-provider-openstack/docs/quickstart',
+                    'container/components/cluster-stacks/components/cluster-stack-provider-openstack/docs/controllers',
+                    'container/components/cluster-stacks/components/cluster-stack-provider-openstack/docs/develop'
+                  ]
+                }
+              ]
+            },
+            {
+              type: 'category',
               label: 'Container Registry',
               link: {
                 type: 'generated-index'

--- a/static/data/architecturalOverviewData.json
+++ b/static/data/architecturalOverviewData.json
@@ -29,16 +29,16 @@
       "buttonText": "Learn More",
       "components": [
         {
-          "title": "k8s Cluster API Provider",
+          "title": "KaaS V1: K8s Cluster API Provider",
           "url": "/docs/category/k8s-cluster-api-provider",
           "mandatory": "false",
           "stable": "true"
         },
         {
-          "title": "Cluster Stacks",
-          "url": "/docs/container",
+          "title": "KaaS V2: Cluster Stacks",
+          "url": "/docs/category/cluster-stacks",
           "mandatory": "false",
-          "stable": "false"
+          "stable": "true"
         },
         {
           "title": "Container Registry",


### PR DESCRIPTION
This PR adds cluster stacks' (KaaS V2) CSPO component docs and displays the cluster stacks on the overview map

Related to https://github.com/SovereignCloudStack/docs/issues/136