### PR TITLE
Show Supplements in Standards overview, group with main document

### DIFF
--- a/populateStds.js
+++ b/populateStds.js
@@ -34,6 +34,7 @@ filenames.forEach((filename) => {
         id: filename.substring(0, filename.length - 3),
         adrId: components[1],
         version: components[2],
+        slug: filename.substring(12, filename.length - 3),  // 12 == "scs-xxxx-vN-".length
         state: {},
     }
     // now calculate the properties for the columns (plus stable0 as a helper)
@@ -46,8 +47,14 @@ filenames.forEach((filename) => {
     if (track === undefined) return
     if (tracks[track] === undefined) tracks[track] = {}
     var standards = tracks[track]
-    if (standards[obj.adrId] === undefined) standards[obj.adrId] = {versions: []}
-    standards[obj.adrId].versions.push(obj)
+    if (standards[obj.adrId] === undefined) standards[obj.adrId] = {versions: [], supplements: {}}
+    if (obj.type === "Supplement") {
+        var supplements = standards[obj.adrId].supplements
+        if (supplements[obj.slug] === undefined) supplements[obj.slug] = {versions: [], title: obj.title}
+        supplements[obj.slug].versions.push(obj)
+    } else {
+        standards[obj.adrId].versions.push(obj)
+    }
 })
 
 function readPrefixLines(fn) {
@@ -104,6 +111,7 @@ ${headerLegend}
     tlines.push('| --------- | ------------ | ----- | ------- | --------- | ----------- |')
     Object.entries(trackEntry[1]).forEach((standardEntry) => {
         var versions = standardEntry[1].versions
+        var supplements = standardEntry[1].supplements
         var ref = versions[versions.length - 1]
         var effectiveVersions = versions.filter((v) => v.state.effective)
         if (effectiveVersions.length) {
@@ -135,7 +143,7 @@ ${headerLegend}
         ).join(' | ')
         lines.push(`| ${link}  | ${track}  | ${ref.title}  | ${versionList}  |`)
         tlines.push(`| ${link}  | ${ref.title}  | ${versionList}  |`)
-        standardEntry[1].versions.forEach((obj) => {
+        versions.forEach((obj) => {
             var versionItem = {
                 type: 'doc',
                 label: obj.version.toUpperCase(),
@@ -143,6 +151,32 @@ ${headerLegend}
             }
             standardItem.items.push(versionItem)
             slines.push(`| [scs-${adrId}-${obj.version}](/standards/${obj.id})  | ${obj.type}  | ${obj.status}  | ${obj.stabilized_at || '-'}  | ${obj.obsoleted_at || '-'}  |`)
+        })
+        Object.values(supplements).forEach((obj) => {
+            // var link = `[scs-${adrId}](/standards/${track.toLowerCase()}/scs-${adrId})`
+            var title = obj.title
+            var versions = obj.versions
+            var versionList = ['draft', 'stable', 'effective', 'deprecated'].map(
+                (column) => mkLinkList(versions.filter((v) => v.state[column])) || '-'
+            ).join(' | ')
+            if (title.startsWith(ref.title)) {
+                title = title.substring(ref.title.length)
+                if (title.startsWith(':')) title = title.substring(1).trimStart()
+            }
+            lines.push(`|   |   | Supplement: ${title}  | ${versionList} |`)
+            tlines.push(`|   | Supplement: ${title}  | ${versionList} |`)
+            slines.push(`\n## Supplement: ${title}\n`)
+            slines.push('| Version  | State   | stabilized | obsoleted |')
+            slines.push('| -------- | ------- | ---------- | --------- |')
+            versions.forEach((obj) => {
+                var versionItem = {
+                    type: 'doc',
+                    label: obj.version.toUpperCase(),
+                    id: obj.id,
+                }
+                standardItem.items.push(versionItem)
+                slines.push(`| [open](/standards/${obj.id})  | ${obj.status}  | ${obj.stabilized_at || '-'}  | ${obj.obsoleted_at || '-'}  |`)
+            })
         })
         slines.push('')  // file should end with a single newline character
         fs.writeFileSync(`${trackPath}/scs-${adrId}.md`, slines.join('\n'), 'utf8')


### PR DESCRIPTION
resolves #156

the supplements field is ignored, rather the Supplement is grouped according to document number