### PR TITLE
Upgrade k8s that hosts SCS Registry to R6

### DIFF
--- a/community/central-services/plusserver-gx-scs.md
+++ b/community/central-services/plusserver-gx-scs.md
@@ -23,7 +23,7 @@ Utilization:
 
 Spec:
 
-- version: v6.0.0 - R5
+- version: v7.0.0 - R6
 - management cluster:
   - 1 instance: SCS-2V:4:20
   - image: Ubuntu 22.04 (20230416)
@@ -32,8 +32,8 @@ Spec:
   - 6 instances:
     - 3 control-planes: SCS-2V:4:20
     - 3 workers: SCS-8V:16:100
-  - image: ubuntu-capi-image-v1.27.5
-  - k8s: v1.27.5
+  - image: ubuntu-capi-image-v1.28.7
+  - k8s: v1.28.7
 
 ## Project p500924-sig-monitoring1
 


### PR DESCRIPTION
Related to SovereignCloudStack/k8s-harbor#64