### PR TITLE
Feat: Add status page docs

### DIFF
--- a/docs.package.json
+++ b/docs.package.json
@@ -46,7 +46,19 @@
     "repo": "SovereignCloudStack/status-page-openapi",
     "source": "docs",
     "target": "docs/04-operating-scs/components",
-    "label": "status-page"
+    "label": "status-page-openapi"
+  },
+  {
+    "repo": "SovereignCloudStack/status-page-api",
+    "source": "docs",
+    "target": "docs/04-operating-scs/components",
+    "label": "status-page-api"
+  },
+  {
+    "repo": "SovereignCloudStack/status-page-deployment",
+    "source": "docs",
+    "target": "docs/04-operating-scs/components",
+    "label": "status-page-deployment"
   },
   {
     "repo": "SovereignCloudStack/k8s-observability",

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -239,8 +239,13 @@ const sidebarsDocs = {
                     type: 'generated-index'
                   },
                   items: [
+                    'operating-scs/components/status-page-api/docs/overview',
+                    'operating-scs/components/status-page-api/docs/requirements',
+                    'operating-scs/components/status-page-api/docs/quickstart',
+                    'operating-scs/components/status-page-api/docs/configuration',
                     'operating-scs/components/status-page-api/docs/requests',
-                    'operating-scs/components/status-page-api/docs/example-requests'
+                    'operating-scs/components/status-page-api/docs/example-requests',
+                    'operating-scs/components/status-page-api/docs/contribute'
                   ]
                 },
                 {

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -242,6 +242,8 @@ const sidebarsDocs = {
                   },
                   items: [
                     'operating-scs/components/status-page-deployment/docs/overview',
+                    'operating-scs/components/status-page-deployment/docs/requirements',
+                    'operating-scs/components/status-page-deployment/docs/quickstart',
                     {
                       type: 'category',
                       label: 'Configuration',
@@ -255,7 +257,9 @@ const sidebarsDocs = {
                         'operating-scs/components/status-page-deployment/docs/scs-public'
                       ]
                     },
-                    'operating-scs/components/status-page-deployment/docs/usage'
+                    'operating-scs/components/status-page-deployment/docs/usage',
+                    'operating-scs/components/status-page-deployment/docs/contribute',
+                    'operating-scs/components/status-page-deployment/docs/faq'
                   ]
                 }
               ]

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -272,6 +272,7 @@ const sidebarsDocs = {
                       ]
                     },
                     'operating-scs/components/status-page-deployment/docs/usage',
+                    'operating-scs/components/status-page-deployment/docs/monitoring',
                     'operating-scs/components/status-page-deployment/docs/contribute',
                     'operating-scs/components/status-page-deployment/docs/admin-authentication',
                     'operating-scs/components/status-page-deployment/docs/faq'

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -219,7 +219,6 @@ const sidebarsDocs = {
                 type: 'generated-index'
               },
               items: [
-                'operating-scs/components/status-page-openapi/docs/overview',
                 {
                   type: 'category',
                   label: 'Concepts',
@@ -227,6 +226,7 @@ const sidebarsDocs = {
                     type: 'generated-index'
                   },
                   items: [
+                    'operating-scs/components/status-page-openapi/docs/overview',
                     'operating-scs/components/status-page-openapi/docs/components',
                     'operating-scs/components/status-page-openapi/docs/levels_of_consensus',
                     'operating-scs/components/status-page-openapi/docs/component_overview'

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -214,15 +214,50 @@ const sidebarsDocs = {
           items: [
             {
               type: 'category',
-              label: 'Status Page API',
+              label: 'Status Page',
               link: {
                 type: 'generated-index'
               },
               items: [
-                'operating-scs/components/status-page/docs/overview',
-                'operating-scs/components/status-page/docs/component_overview',
-                'operating-scs/components/status-page/docs/components',
-                'operating-scs/components/status-page/docs/levels_of_consensus'
+                'operating-scs/components/status-page-openapi/docs/overview',
+                {
+                  type: 'category',
+                  label: 'API',
+                  link: {
+                    type: 'generated-index'
+                  },
+                  items: [
+                    'operating-scs/components/status-page-openapi/docs/components',
+                    'operating-scs/components/status-page-openapi/docs/levels_of_consensus',
+                    'operating-scs/components/status-page-openapi/docs/component_overview',
+                    'operating-scs/components/status-page-api/docs/requests',
+                    'operating-scs/components/status-page-api/docs/example-requests'
+                  ]
+                },
+                {
+                  type: 'category',
+                  label: 'Deployment',
+                  link: {
+                    type: 'generated-index'
+                  },
+                  items: [
+                    'operating-scs/components/status-page-deployment/docs/overview',
+                    {
+                      type: 'category',
+                      label: 'Configuration',
+                      link: {
+                        type: 'generated-index'
+                      },
+                      items: [
+                        'operating-scs/components/status-page-deployment/docs/configuration',
+                        'operating-scs/components/status-page-deployment/docs/kind',
+                        'operating-scs/components/status-page-deployment/docs/k3s',
+                        'operating-scs/components/status-page-deployment/docs/scs-public'
+                      ]
+                    },
+                    'operating-scs/components/status-page-deployment/docs/usage'
+                  ]
+                }
               ]
             },
             {
@@ -267,7 +302,7 @@ const sidebarsDocs = {
                 'operating-scs/components/automated-pentesting/overview',
                 'operating-scs/components/automated-pentesting/tools'
               ]
-            },
+            }
           ]
         },
         {
@@ -354,7 +389,10 @@ const sidebarsDocs = {
           link: {
             type: 'generated-index'
           },
-          items: ['iam/domain-manager-setup-and-usage', 'iam/SCS-example-setup-configuration-description']
+          items: [
+            'iam/domain-manager-setup-and-usage',
+            'iam/SCS-example-setup-configuration-description'
+          ]
         },
         'iam/intra-SCS-federation-setup-description-for-osism-doc-operations'
       ]

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -222,14 +222,23 @@ const sidebarsDocs = {
                 'operating-scs/components/status-page-openapi/docs/overview',
                 {
                   type: 'category',
-                  label: 'API',
+                  label: 'Concepts',
                   link: {
                     type: 'generated-index'
                   },
                   items: [
                     'operating-scs/components/status-page-openapi/docs/components',
                     'operating-scs/components/status-page-openapi/docs/levels_of_consensus',
-                    'operating-scs/components/status-page-openapi/docs/component_overview',
+                    'operating-scs/components/status-page-openapi/docs/component_overview'
+                  ]
+                },
+                {
+                  type: 'category',
+                  label: 'API',
+                  link: {
+                    type: 'generated-index'
+                  },
+                  items: [
                     'operating-scs/components/status-page-api/docs/requests',
                     'operating-scs/components/status-page-api/docs/example-requests'
                   ]

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -273,6 +273,7 @@ const sidebarsDocs = {
                     },
                     'operating-scs/components/status-page-deployment/docs/usage',
                     'operating-scs/components/status-page-deployment/docs/contribute',
+                    'operating-scs/components/status-page-deployment/docs/admin-authentication',
                     'operating-scs/components/status-page-deployment/docs/faq'
                   ]
                 }

--- a/static/data/architecturalOverviewData.json
+++ b/static/data/architecturalOverviewData.json
@@ -8,7 +8,7 @@
       "components": [
         {
           "title": "Status Page",
-          "url": "/docs/operating-scs/components/status-page/docs/overview",
+          "url": "/docs/category/status-page",
           "mandatory": "true",
           "stable": "true"
         },


### PR DESCRIPTION
Adding the missing docs about all parts the status page.

Closes: SovereignCloudStack/issues#610
