### PR TITLE
Fix Linting Errors

### DIFF
--- a/populateStds.js
+++ b/populateStds.js
@@ -201,9 +201,9 @@ ${headerLegend}
                 title = title.substring(ref.title.length)
                 if (title.startsWith(':')) title = title.substring(1).trimStart()
             }
-            lines.push(`|   |   | Supplement: ${title}  | ${versionList} |`)
-            tlines.push(`|   | Supplement: ${title}  | ${versionList} |`)
-            slines.push(`\n## Supplement: ${title}\n`)
+            lines.push(`|   |   | Supplement: ${title.trim()}  | ${versionList} |`)
+            tlines.push(`|   | Supplement: ${title.trim() }  | ${versionList} |`)
+            slines.push(`\n## Supplement: ${title.trim() }\n`)
             slines.push('| Version  | State   | stabilized | deprecated |')
             slines.push('| -------- | ------- | ---------- | ---------- |')
             versions.forEach((obj) => {

--- a/populateStds.js
+++ b/populateStds.js
@@ -199,11 +199,12 @@ ${headerLegend}
             ).join(' | ')
             if (title.startsWith(ref.title)) {
                 title = title.substring(ref.title.length)
-                if (title.startsWith(':')) title = title.substring(1).trimStart()
+                if (title.startsWith(':')) title = title.substring(1)
+                title = title.trimStart()
             }
-            lines.push(`|   |   | Supplement: ${title.trim()}  | ${versionList} |`)
-            tlines.push(`|   | Supplement: ${title.trim() }  | ${versionList} |`)
-            slines.push(`\n## Supplement: ${title.trim() }\n`)
+            lines.push(`|   |   | Supplement: ${title}  | ${versionList} |`)
+            tlines.push(`|   | Supplement: ${title}  | ${versionList} |`)
+            slines.push(`\n## Supplement: ${title}\n`)
             slines.push('| Version  | State   | stabilized | deprecated |')
             slines.push('| -------- | ------- | ---------- | ---------- |')
             versions.forEach((obj) => {


### PR DESCRIPTION
* Add misssing `trim()` to avoid double white spaces in standards generation code

as seen here: https://github.com/SovereignCloudStack/docs/actions/runs/10042568134/job/27850074200?pr=87#step:6:14