### PR TITLE
feat(security): Add KaaS pentesting tools to docs

### DIFF
--- a/docs.package.json
+++ b/docs.package.json
@@ -98,13 +98,19 @@
     "repo": "SovereignCloudStack/security-infra-scan-pipeline",
     "source": "docs/*.md",
     "target": "docs/04-operating-scs/components",
-    "label": "automated-pentesting"
+    "label": "automated-pentesting-iaas"
   },
   {
     "repo": "SovereignCloudStack/security-infra-scan-pipeline",
     "source": "docs/images/*.png",
     "target": "docs/04-operating-scs/components",
-    "label": "automated-pentesting/images"
+    "label": "automated-pentesting-iaas/images"
+  },
+  {
+    "repo": "SovereignCloudStack/security-k8s-scan-pipeline",
+    "source": "docs/*.md",
+    "target": "docs/04-operating-scs/components",
+    "label": "automated-pentesting-kaas"
   },
   {
     "repo": "SovereignCloudStack/csctl",

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -381,9 +381,30 @@ const sidebarsDocs = {
                 type: 'generated-index'
               },
               items: [
-                'operating-scs/components/automated-pentesting/overview',
-                'operating-scs/components/automated-pentesting/quickstart',
-                'operating-scs/components/automated-pentesting/tools'
+                {
+                  type: 'category',
+                  label: 'Pentesting IaaS',
+                  link: {
+                    type: 'generated-index'
+                  },
+                  items: [
+                    'operating-scs/components/automated-pentesting-iaas/overview',
+                    'operating-scs/components/automated-pentesting-iaas/quickstart',
+                    'operating-scs/components/automated-pentesting-iaas/tools'
+                  ]
+                },
+                {
+                  type: 'category',
+                  label: 'Pentesting KaaS',
+                  link: {
+                    type: 'generated-index'
+                  },
+                  items: [
+                    'operating-scs/components/automated-pentesting-kaas/overview',
+                    'operating-scs/components/automated-pentesting-kaas/quickstart',
+                    'operating-scs/components/automated-pentesting-kaas/tools'
+                  ]
+                }
               ]
             }
           ]

--- a/static/data/architecturalOverviewData.json
+++ b/static/data/architecturalOverviewData.json
@@ -31,8 +31,14 @@
           "stable": "true"
         },
         {
-          "title": "Automated Pentesting",
-          "url": "/docs/operating-scs/components/automated-pentesting/overview",
+          "title": "Automated Pentesting IaaS",
+          "url": "/docs/operating-scs/components/automated-pentesting-iaas/overview",
+          "mandatory": "true",
+          "stable": "true"
+        },
+        {
+          "title": "Automated Pentesting KaaS",
+          "url": "/docs/operating-scs/components/automated-pentesting-kaas/overview",
           "mandatory": "true",
           "stable": "true"
         }


### PR DESCRIPTION
Integrates the KaaS security tooling docs into the docs.

Rename previously added "automated-pentesting" entry to "-iaas" and add "-kaas". Both sections are now under-categories and are both displayed in the component overview.