### PR TITLE
Adjust checks: linter and link checker  

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -55,6 +55,6 @@
     "markdownlint-rule-search-replace",
     "markdownlint-rule-relative-links"
   ],
-  "ignores": ["node_modules", ".github", "docs"],
+  "ignores": ["node_modules", ".github", "docs", "standards"],
   "globs": ["**/*.{md}"]
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   tagline: 'Documentation and Community Platform for the Sovereign Cloud Stack',
   url: 'https://docs.scs.community',
   baseUrl: '/',
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   markdown: {


### PR DESCRIPTION
* remove `standards` repo from being linted in this repo, which leads to unnecessary failing checks
* change onBrokenLinks (docusaurus internal checker during each build process, which is separate to our additional markdown-lint-checker) behavior from `throw` to `warn` to allow relative links from docs of external repo (so even more important to read the logs carefully once a build does not succeed)