### PR TITLE
Fix spelling of openDesk

### DIFF
--- a/sidebarsUserDocs.js
+++ b/sidebarsUserDocs.js
@@ -13,7 +13,7 @@ const sidebars = {
       items: [
         {
           type: 'category',
-          label: 'OpenDesk on SCS',
+          label: 'openDesk on SCS',
           link: {
             type: 'generated-index'
           },


### PR DESCRIPTION
Fix only a small spelling issue in *openDesk*.

Thank you for creating this guide!