### PR TITLE
Remove Cluster Stack Provider OpenStack

### DIFF
--- a/docs.package.json
+++ b/docs.package.json
@@ -12,12 +12,6 @@
     "label": ""
   },
   {
-    "repo": "SovereignCloudStack/cluster-stack-provider-openstack",
-    "source": "docs",
-    "target": "docs/03-container/components/cluster-stacks/components",
-    "label": "cluster-stack-provider-openstack"
-  },
-  {
     "repo": "SovereignCloudStack/standards",
     "source": ["Standards/*.md", "Tests/scs-*.yaml"],
     "target": "standards",

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -141,16 +141,6 @@ const sidebarsDocs = {
                 },
                 {
                   type: 'category',
-                  label: 'Cluster Stack Provider OpenStack',
-                  items: [
-                    'container/components/cluster-stacks/components/cluster-stack-provider-openstack/docs/overview',
-                    'container/components/cluster-stacks/components/cluster-stack-provider-openstack/docs/quickstart',
-                    'container/components/cluster-stacks/components/cluster-stack-provider-openstack/docs/controllers',
-                    'container/components/cluster-stacks/components/cluster-stack-provider-openstack/docs/develop'
-                  ]
-                },
-                {
-                  type: 'category',
                   label: 'csctl',
                   items: [
                     'container/components/cluster-stacks/components/csctl/overview',


### PR DESCRIPTION
We plan to deprecate the CSPO from R8 in favor of the image kind of the OpenStack Resource Controller (ORC).
For archived docs, the CSPO repo can be mentioned.
Should me merge not before `images.openstack.k-orc.cloud` has been added to the Cluster Stacks.