### PR TITLE
Latest is R8, not R7.

### DIFF
--- a/static/data/featureContentData.json
+++ b/static/data/featureContentData.json
@@ -7,8 +7,8 @@
   },
   {
     "title": "Releases",
-    "body": "SCS is currently in Release 7. Check out the latest Release Notes.",
-    "url": "/docs/releases/Release7",
+    "body": "The latest release of the SCS reference implementation is R8. Check out the Release Notes.",
+    "url": "/docs/releases/Release8",
     "buttonText": "Learn More"
   },
   {


### PR DESCRIPTION
Also use the term reference implementation, trying to avoid confusion by having clear and consistent terminology.