### PR TITLE
Move docs build forward 5 hrs

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy to Github Pages
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 5 * * *"
   push:
     branches:
       - main


### PR DESCRIPTION
From 0 am UTC to 5 am UTC, which is 7 am CEST.

Vastly increases the chance that we catch the latest nightly results from the compliance checks, in particular when they are moved back from 3 am UTC to 0 am UTC, as proposed in a concurrent PR: https://github.com/SovereignCloudStack/zuul-scs-jobs/pull/49