### PR TITLE
remove misleading explanation in certification overview

### DIFF
--- a/standards/certification/overview.template.md
+++ b/standards/certification/overview.template.md
@@ -24,6 +24,4 @@ The standard [SCS-0007](https://docs.scs.community/standards/global/scs-0007) de
 
 ## Compliant cloud environments
 
-This is a list of clouds that we test on a nightly basis against the certificate scope _SCS-compatible IaaS_.
-
 <!--CLOUDS-->


### PR DESCRIPTION
The explanation will be moved to the specific tables for IaaS and KaaS. See belonging PR in `standards` repo: SovereignCloudStack/standards#1161