### PR TITLE
document the history of the project board as well as nominees

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Members of the Project Board are the owners of the Community
+# Governance - see: 
+# https://docs.scs.community/community/governance/project-board
+/community/governance/ @SovereignCloudStack/project-board
+

--- a/community/governance/project-board-2025.md
+++ b/community/governance/project-board-2025.md
@@ -10,7 +10,7 @@ For the term 2025 the project board consisted of:
 Spokesperson: Felix Kronlage-Dammers, @fkr
 
 | Name, Firstname         | Github Handle                                  | E-Mail                                                        | Remark                         |
-| ----------------------- | ---------------------------------------------- | ------------------------------------------------------------- |---------------------------------
+| ----------------------- | ---------------------------------------------- | ------------------------------------------------------------- | ------------------------------ |
 | Berendt, Christian      | [@berendt](https://github.com/berendt)         | [berendt@osism.tech](mailto:berendt@osism.tech)               | Elected by Community           |
 | Feder, Matej            | [@matofeder](https://github.com/matofeder)     | [matej.feder@dnation.cloud](mailto:matej.feder@dnation.cloud) | Elected by Community           |
 | Garloff, Kurt           | [@garloff](https://github.com/garloff)         | [scs@garloff.de](mailto:scs@garloff.de)                       | Elected by Community           |

--- a/community/governance/project-board-2025.md
+++ b/community/governance/project-board-2025.md
@@ -1,0 +1,35 @@
+# The SCS Project Board
+
+The governance of the community is described in the procedural standard [SCS-0005](https://docs.scs.community/standards/global/scs-0005).
+The SCS Project Board can be reached via e-mail: [project-board@lists.scs.community](mailto:project-board@lists.scs.community).
+
+## Project Board Term 2025
+
+For the term 2025 the project board consisted of:
+
+Spokesperson: Felix Kronlage-Dammers, @fkr
+
+| Name, Firstname         | Github Handle                                  | E-Mail                                                       | Remark                         |
+| ----------------------- | ---------------------------------------------- | ------------------------------------------------------------ |---------------------------------
+| Berendt, Christian      | [@berendt](https://github.com/berendt)         | [berendt@osism.tech](mailto:berendt@osism.tech)              | Elected by Community           |
+| Feder, Matej            | [@matofeder](https://github.com/matofeder)     | [matej.feder@dnation.cloud](mailto:matej.feder@dnation.cloud)| Elected by Community           |
+| Garloff, Kurt           | [@garloff](https://github.com/garloff)         | [scs@garloff.de](mailto:scs@garloff.de)                      | Elected by Community           |
+| Kronlage-Dammers, Felix | [@fkr](https://github.com/fkr)                 | [fkr@osb-alliance.com](mailto:fkr@osb-alliance.com)          | Represents Forum SCS-Standards |
+| Schoone, Jan            | [@jschoone](https://github.com/jschoone)       | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)  | Elected by Community           |
+
+## Project Board Term 2025 Nominees
+
+For the project board election for the term 2025 the following people were nominated or have nominated themselves:
+
+| Name, Firstname     | Github Handle                                          | E-Mail                                                                             |
+| ------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Bayr, Michael       | [@michaelbayr](https://github.com/michaelbayr)         | [mb@artcodix.com](mailto:mb@artcodix.com)                                          |
+| Berendt, Christian  | [@berendt](https://github.com/berendt)                 | [berendt@osism.tech](mailto:berendt@osism.tech)                                    |
+| Büchse, Matthias    | [@mbuechse](https://github.com/mbuechse)               | [matthias.buechse@cloudandheat.com](mailto:matthias.buechse@cloudandheat.com)      |
+| Feder, Matej        | [@matofeder](https://github.com/matofeder)             | [matej.feder@dnation.cloud](mailto:matej.feder@dnation.cloud)                      |
+| Garloff, Kurt       | [@garloff](https://github.com/garloff)                 | [scs@garloff.de](mailto:scs@garloff.de)                                            |
+| Kemper, Janis       | [@janiskemper](https://github.com/janiskemper)         | [janis.kemper@syself.com](mailto:janis.kemper@syself.com)                          |
+| Schäfer, Jonas      | [@horazont](https://github.com/horazont)               | [jonas.schaefer@cloudandheat.com](mailto:jonas.schaefer@cloudandheat.com)          |
+| Schoone, Jan        | [@jschoone](https://github.com/jschoone)               | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)                        |
+| Wolf, Tobias        | [@NotTheEvilOne](https://github.com/NotTheEvilOne)     | [wolf@b1-systems.de](mailto:wolf@b1-systems.de)                                    |
+

--- a/community/governance/project-board-2025.md
+++ b/community/governance/project-board-2025.md
@@ -9,13 +9,13 @@ For the term 2025 the project board consisted of:
 
 Spokesperson: Felix Kronlage-Dammers, @fkr
 
-| Name, Firstname         | Github Handle                                  | E-Mail                                                       | Remark                         |
-| ----------------------- | ---------------------------------------------- | ------------------------------------------------------------ |---------------------------------
-| Berendt, Christian      | [@berendt](https://github.com/berendt)         | [berendt@osism.tech](mailto:berendt@osism.tech)              | Elected by Community           |
-| Feder, Matej            | [@matofeder](https://github.com/matofeder)     | [matej.feder@dnation.cloud](mailto:matej.feder@dnation.cloud)| Elected by Community           |
-| Garloff, Kurt           | [@garloff](https://github.com/garloff)         | [scs@garloff.de](mailto:scs@garloff.de)                      | Elected by Community           |
-| Kronlage-Dammers, Felix | [@fkr](https://github.com/fkr)                 | [fkr@osb-alliance.com](mailto:fkr@osb-alliance.com)          | Represents Forum SCS-Standards |
-| Schoone, Jan            | [@jschoone](https://github.com/jschoone)       | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)  | Elected by Community           |
+| Name, Firstname         | Github Handle                                  | E-Mail                                                        | Remark                         |
+| ----------------------- | ---------------------------------------------- | ------------------------------------------------------------- |---------------------------------
+| Berendt, Christian      | [@berendt](https://github.com/berendt)         | [berendt@osism.tech](mailto:berendt@osism.tech)               | Elected by Community           |
+| Feder, Matej            | [@matofeder](https://github.com/matofeder)     | [matej.feder@dnation.cloud](mailto:matej.feder@dnation.cloud) | Elected by Community           |
+| Garloff, Kurt           | [@garloff](https://github.com/garloff)         | [scs@garloff.de](mailto:scs@garloff.de)                       | Elected by Community           |
+| Kronlage-Dammers, Felix | [@fkr](https://github.com/fkr)                 | [fkr@osb-alliance.com](mailto:fkr@osb-alliance.com)           | Represents Forum SCS-Standards |
+| Schoone, Jan            | [@jschoone](https://github.com/jschoone)       | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)   | Elected by Community           |
 
 ## Project Board Term 2025 Nominees
 
@@ -32,4 +32,3 @@ For the project board election for the term 2025 the following people were nomin
 | Schäfer, Jonas      | [@horazont](https://github.com/horazont)               | [jonas.schaefer@cloudandheat.com](mailto:jonas.schaefer@cloudandheat.com)          |
 | Schoone, Jan        | [@jschoone](https://github.com/jschoone)               | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)                        |
 | Wolf, Tobias        | [@NotTheEvilOne](https://github.com/NotTheEvilOne)     | [wolf@b1-systems.de](mailto:wolf@b1-systems.de)                                    |
-

--- a/community/governance/project-board-2025.md
+++ b/community/governance/project-board-2025.md
@@ -1,9 +1,4 @@
-# The SCS Project Board
-
-The governance of the community is described in the procedural standard [SCS-0005](https://docs.scs.community/standards/global/scs-0005).
-The SCS Project Board can be reached via e-mail: [project-board@lists.scs.community](mailto:project-board@lists.scs.community).
-
-## Project Board Term 2025
+# Project Board Term 2025
 
 For the term 2025 the project board consisted of:
 

--- a/community/governance/project-board.md
+++ b/community/governance/project-board.md
@@ -27,7 +27,7 @@ For the project board election for the term 2026 the following people were nomin
 | Bayr, Michael       | [@michaelbayr](https://github.com/michaelbayr)   | [mb@artcodix.com](mailto:mb@artcodix.com)                           |
 | Berendt, Christian  | [@berendt](https://github.com/berendt)           | [berendt@osism.tech](mailto:berendt@osism.tech)                     |
 | Garloff, Kurt       | [@garloff](https://github.com/garloff)           | [scs@garloff.de](mailto:scs@garloff.de)                             |
-| Klare, Jan          | [@jklare](https://github.com/jklare)             | [klare@osism.tech](mailto:klare@osism.tech)                         |
+| Klare, Jan          | [@jklare](https://github.com/jklare)             | [klare@osism.de](mailto:klare@osism.de)                         |
 | Pilka, Martin       | [@mpilka](https://github.com/mpilka)             | [martin.pilka@dnation.cloud](mailto:martin.pilka@dnation.cloud)     |
 | Schöchlin, Marc     | [@scoopex](https://github.com/scoopex)           | [marc.schoechlin@uhurutec.com](mailto:marc.schoechlin@uhurutec.com) |
 | Schoone, Jan        | [@jschoone](https://github.com/jschoone)         | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)         |

--- a/community/governance/project-board.md
+++ b/community/governance/project-board.md
@@ -17,3 +17,17 @@ Spokesperson: Kurt Garloff, @garloff
 | Klare, Jan              | [@jklare](https://github.com/jklare)           | [klare@osism.tech](mailto:klare@osism.tech)                  | Elected by Community                      |
 | Kronlage-Dammers, Felix | [@fkr](https://github.com/fkr)                 | [fkr@osb-alliance.com](mailto:fkr@osb-alliance.com)          | Represents Forum SCS-Standards            |
 | Schoone, Jan            | [@jschoone](https://github.com/jschoone)       | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)  | Elected by Community                      |
+
+## Project Board Term 2026 Nominees
+
+For the project board election for the term 2026 the following people were nominated or have nominated themselves:
+
+| Name, Firstname     | Github Handle                                    | E-Mail                                                              |
+| ------------------- | ------------------------------------------------ | ------------------------------------------------------------------- |
+| Bayr, Michael       | [@michaelbayr](https://github.com/michaelbayr)   | [mb@artcodix.com](mailto:mb@artcodix.com)                           |
+| Berendt, Christian  | [@berendt](https://github.com/berendt)           | [berendt@osism.tech](mailto:berendt@osism.tech)                     |
+| Garloff, Kurt       | [@garloff](https://github.com/garloff)           | [scs@garloff.de](mailto:scs@garloff.de)                             |
+| Klare, Jan          | [@jklare](https://github.com/jklare)             | [klare@osism.tech](mailto:klare@osism.tech)                         |
+| Pilka, Martin       | [@mpilka](https://github.com/mpilka)             | [martin.pilka@dnation.cloud](mailto:martin.pilka@dnation.cloud)     |
+| Schöchlin, Marc     | [@scoopex](https://github.com/scoopex)           | [marc.schoechlin@uhurutec.com](mailto:marc.schoechlin@uhurutec.com) |
+| Schoone, Jan        | [@jschoone](https://github.com/jschoone)         | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)         |

--- a/community/governance/project-board.md
+++ b/community/governance/project-board.md
@@ -27,7 +27,7 @@ For the project board election for the term 2026 the following people were nomin
 | Bayr, Michael       | [@michaelbayr](https://github.com/michaelbayr)   | [mb@artcodix.com](mailto:mb@artcodix.com)                           |
 | Berendt, Christian  | [@berendt](https://github.com/berendt)           | [berendt@osism.tech](mailto:berendt@osism.tech)                     |
 | Garloff, Kurt       | [@garloff](https://github.com/garloff)           | [scs@garloff.de](mailto:scs@garloff.de)                             |
-| Klare, Jan          | [@jklare](https://github.com/jklare)             | [klare@osism.de](mailto:klare@osism.de)                         |
+| Klare, Jan          | [@jklare](https://github.com/jklare)             | [klare@osism.de](mailto:klare@osism.de)                             |
 | Pilka, Martin       | [@mpilka](https://github.com/mpilka)             | [martin.pilka@dnation.cloud](mailto:martin.pilka@dnation.cloud)     |
 | Schöchlin, Marc     | [@scoopex](https://github.com/scoopex)           | [marc.schoechlin@uhurutec.com](mailto:marc.schoechlin@uhurutec.com) |
 | Schoone, Jan        | [@jschoone](https://github.com/jschoone)         | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)         |

--- a/community/governance/project-board.md
+++ b/community/governance/project-board.md
@@ -14,7 +14,7 @@ Spokesperson: Kurt Garloff, @garloff
 | Bayr, Michael           | [@michaelbayr](https://github.com/michaelbayr) | [mb@artcodix.com](mailto:mb@artcodix.com)                    | Elected by Community                      |
 | Garloff, Kurt           | [@garloff](https://github.com/garloff)         | [scs@garloff.de](mailto:scs@garloff.de)                      | Elected by Community                      |
 | Kemper, Janis           | [@janiskemper](https://github.com/janiskemper) | [janis.kemper@syself.com](mailto:janis.kemper@syself.com)    | Deputy Representative Forum SCS-Standards |
-| Klare, Jan              | [@jklare](https://github.com/jklare)           | [klare@osism.tech](mailto:klare@osism.tech)                  | Elected by Community                      |
+| Klare, Jan              | [@jklare](https://github.com/jklare)           | [klare@osism.de](mailto:klare@osism.de)                      | Elected by Community                      |
 | Kronlage-Dammers, Felix | [@fkr](https://github.com/fkr)                 | [fkr@osb-alliance.com](mailto:fkr@osb-alliance.com)          | Represents Forum SCS-Standards            |
 | Schoone, Jan            | [@jschoone](https://github.com/jschoone)       | [jan.schoone@uhurutec.com](mailto:jan.schoone@uhurutec.com)  | Elected by Community                      |
 

--- a/sidebarsCommunity.js
+++ b/sidebarsCommunity.js
@@ -15,6 +15,7 @@ const sidebars = {
       label: 'Governance',
       items: [
         'governance/project-board'
+        'governance/project-board-2025'
       ]
     },
     {

--- a/sidebarsCommunity.js
+++ b/sidebarsCommunity.js
@@ -14,7 +14,7 @@ const sidebars = {
       },
       label: 'Governance',
       items: [
-        'governance/project-board'
+        'governance/project-board',
         'governance/project-board-2025'
       ]
     },


### PR DESCRIPTION
This originates from the idea to clean-up the Standards repository by @mbuechse. See sovereigncloudstack/standards#1197