### PR TITLE
Speed up getDocs clones with shallow, single-branch fetch

### DIFF
--- a/getDocs.js
+++ b/getDocs.js
@@ -14,8 +14,10 @@ const ghUrl = 'https://github.com/'
 repos.forEach((repo) => {
   const repoDir = `repo_to_be_edited/${repo.label}`
 
-  // Clone the repository
-  const cloneCommand = `git clone ${ghUrl + repo.repo} ${repoDir}`
+  // Clone the repository (shallow, single branch — we only need a snapshot of the docs)
+  const cloneCommand = `git clone --single-branch --depth 1 ${
+    ghUrl + repo.repo
+  } ${repoDir}`
   execSync(cloneCommand)
 
   // Remove git folders

--- a/getDocs.js
+++ b/getDocs.js
@@ -21,7 +21,7 @@ repos.forEach((repo) => {
   const repoDir = `repo_to_be_edited/${repo.label}`
 
   // Clone the repository (shallow, single branch — we only need a snapshot of the docs)
-  const cloneCommand = `git clone --single-branch --depth 1 ${cloneUrl(repo.repo)} ${repoDir}`
+  const cloneCommand = `git clone --depth 1 ${cloneUrl(repo.repo)} ${repoDir}`
   execSync(cloneCommand)
 
   // Remove git folders


### PR DESCRIPTION
getDocs.js only needs a snapshot of each upstream repo's docs, but it did a full clone (entire history, all branches). Add `--depth 1` and `--single-branch` so each clone transfers only the latest commit of the default branch, cutting fetch time and bandwidth noticeably for the larger source repositories.