### PR TITLE
Remove unsupported Cloud-in-a-Box guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /docs/02-iaas/guides/troubleshooting-guides
 /docs/02-iaas/guides/upgrade-guides
 /docs/02-iaas/guides/index.md
-/docs/02-iaas/deployment-examples/cloud-in-a-box
 /docs/02-iaas/deployment-examples/testbed
 /docs/03-container/components
 /docs/04-operating-scs/components

--- a/docs.package.json
+++ b/docs.package.json
@@ -25,12 +25,6 @@
   },
   {
     "repo": "osism/osism.github.io",
-    "source": "docs/cloud-in-a-box",
-    "target": "docs/02-iaas/deployment-examples",
-    "label": ""
-  },
-  {
-    "repo": "osism/osism.github.io",
     "source": "docs/testbed",
     "target": "docs/02-iaas/deployment-examples",
     "label": ""

--- a/docs/08-faq/index.mdx
+++ b/docs/08-faq/index.mdx
@@ -61,7 +61,6 @@ KaaS refers to Kubernetes as a Service, where providers offer Kubernetes Cluster
 
 **As a Cloud Service Provider**:
 
-- **Cloud in a Box**: Start with our pre-packaged solutions. [Link to Ciab](https://docs.scs.community/docs/iaas/deployment-examples/cloud-in-a-box/advanced-guides/cloud-in-a-box)
 - **Testbed**: Use the SCS test environment to experiment. [Link to Testbed/deployment example](https://docs.scs.community/docs/iaas/deployment-examples/cloud-in-a-box/advanced-guides/testbed)
 
 ## I want to use an SCS Cloud! How do I get started?

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -20,14 +20,6 @@ SCS is built, backed, and operated by an active open-source community worldwide.
 
 The SCS IaaS Reference Implementation is based on [OSISM](https://osism.tech/).
 
-#### Quick Start with Cloud-in-a-Box
-
-You can do a single node installation for learning, testing or development purposes.
-The Cloud-in-a-Box configuration was built explicitly for this scenario.
-Check it out [here](/docs/iaas/deployment-examples/cloud-in-a-box)
-It comes with a complete set of services, even Ceph is part of it
-(despite of course not offering much redundancy on a single-node).
-
 #### Reference Implementation Testbed
 
 The fastest way to get in touch with SCS is to deploy a SCS cloud virtually.


### PR DESCRIPTION
Currently the build pipeline is broken. I tried to remove the missing pieces. Not sure if I got everything. 

OSISM removed the [docs/cloud-in-a-box guide from osism.github.io](https://github.com/osism/osism.github.io/pull/1023) ("Cloud in a Box is currently unsupported but was prominently featured in the documentation"), which breaks getDocs.js since the source directory it copied no longer exists.

Mirror that removal here:
- drop the cloud-in-a-box entry from docs.package.json so getDocs.js no longer tries to fetch the deleted directory
- drop the now-unused .gitignore entry for the fetched output
- remove the "Quick Start with Cloud-in-a-Box" section in docs/index.mdx (its internal link pointed at the removed guide and broke the build)
- remove the Cloud in a Box bullet in the FAQ

Historical release-notes mentions and the incidental Cloud-in-a-Box note in the openstack-health-monitor guide are left untouched.