### PR TITLE
docs: remove orphaned placeholder pages

### DIFF
--- a/docs/02-iaas/overview/architecture.md
+++ b/docs/02-iaas/overview/architecture.md
@@ -1,3 +1,0 @@
-# Architecture
-
-TODO

--- a/docs/02-iaas/overview/compute.md
+++ b/docs/02-iaas/overview/compute.md
@@ -1,3 +1,0 @@
-# Compute
-
-TODO

--- a/docs/02-iaas/overview/knowledge.md
+++ b/docs/02-iaas/overview/knowledge.md
@@ -1,3 +1,0 @@
-# Knowledge
-
-TODO

--- a/docs/02-iaas/overview/network.md
+++ b/docs/02-iaas/overview/network.md
@@ -1,3 +1,0 @@
-# Network
-
-TODO

--- a/docs/02-iaas/overview/storage.md
+++ b/docs/02-iaas/overview/storage.md
@@ -1,3 +1,0 @@
-# Storage
-
-TODO

--- a/docs/03-container/deployment-examples/a/hardware.md
+++ b/docs/03-container/deployment-examples/a/hardware.md
@@ -1,3 +1,0 @@
-# Hardware Requirements
-
-TODO

--- a/docs/03-container/deployment-examples/a/index.md
+++ b/docs/03-container/deployment-examples/a/index.md
@@ -1,3 +1,0 @@
-# Overview
-
-TODO

--- a/docs/03-container/deployment-examples/a/software.md
+++ b/docs/03-container/deployment-examples/a/software.md
@@ -1,3 +1,0 @@
-# Software Requirements
-
-TODO

--- a/docs/03-container/guides/guide1.md
+++ b/docs/03-container/guides/guide1.md
@@ -1,3 +1,0 @@
-# Guide 1
-
-TODO

--- a/docs/03-container/overview/architecture.md
+++ b/docs/03-container/overview/architecture.md
@@ -1,3 +1,0 @@
-# Architecture
-
-TODO

--- a/docs/03-container/overview/knowledge.md
+++ b/docs/03-container/overview/knowledge.md
@@ -1,3 +1,0 @@
-# Knowledge
-
-TODO

--- a/docs/04-operating-scs/02-monitoring/index.md
+++ b/docs/04-operating-scs/02-monitoring/index.md
@@ -1,3 +1,0 @@
-# Overview
-
-TODO

--- a/docs/04-operating-scs/03-incident-management/index.md
+++ b/docs/04-operating-scs/03-incident-management/index.md
@@ -1,3 +1,0 @@
-# Overview
-
-TODO

--- a/docs/04-operating-scs/04-audits/index.md
+++ b/docs/04-operating-scs/04-audits/index.md
@@ -1,3 +1,0 @@
-# Overview
-
-TODO

--- a/docs/04-operating-scs/05-lifecycle-management/index.md
+++ b/docs/04-operating-scs/05-lifecycle-management/index.md
@@ -1,3 +1,0 @@
-# Overview
-
-TODO

--- a/docs/04-operating-scs/06-logging/index.md
+++ b/docs/04-operating-scs/06-logging/index.md
@@ -1,3 +1,0 @@
-# Overview
-
-TODO

--- a/docs/04-operating-scs/overview.md
+++ b/docs/04-operating-scs/overview.md
@@ -1,7 +1,0 @@
----
-sidebar: 1
----
-
-# Overview
-
-TODO

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -47,48 +47,6 @@ const sidebarsDocs = {
       items: [
         {
           type: 'category',
-          label: 'Overview',
-          link: {
-            type: 'generated-index'
-          },
-          items: [
-            // 'container/overview/architecture',
-            // 'container/overview/knowledge'
-          ]
-        },
-        {
-          type: 'category',
-          label: 'Deployment Examples',
-          link: {
-            type: 'generated-index'
-          },
-          items: [
-            {
-              type: 'category',
-              label: 'Deployment A',
-              link: {
-                type: 'generated-index'
-              },
-              items: [
-                // 'container/deployment-examples/a/index',
-                // 'container/deployment-examples/a/hardware',
-                // 'container/deployment-examples/a/software'
-              ]
-            }
-          ]
-        },
-        {
-          type: 'category',
-          label: 'Guides',
-          link: {
-            type: 'generated-index'
-          },
-          items: [
-            // 'container/guides/guide1'
-          ]
-        },
-        {
-          type: 'category',
           label: 'Components',
           link: {
             type: 'generated-index'
@@ -166,7 +124,6 @@ const sidebarsDocs = {
         type: 'generated-index'
       },
       items: [
-        // 'operating-scs/overview',
         {
           type: 'category',
           label: 'Components',


### PR DESCRIPTION
## What

Removes 17 dead documentation pages that were carried over from the `docs-page` / `scs-docs` subtree merges but never wired into the consolidated sidebar. Each contained only a heading plus a `TODO` placeholder and was unreachable — no sidebar entry, no inbound links, and not covered by any autogenerated directory.

Deleted trees:
- `docs/02-iaas/overview/` — architecture, compute, knowledge, network, storage
- `docs/03-container/overview/` — architecture, knowledge
- `docs/03-container/deployment-examples/a/` — index, hardware, software
- `docs/03-container/guides/guide1.md`
- `docs/04-operating-scs/overview.md` and the `02-monitoring`, `03-incident-management`, `04-audits`, `05-lifecycle-management`, `06-logging` index pages

## Sidebar cleanup

`sidebarsDocs.js` held dangling references to the deleted files:
- The Container Layer **Overview**, **Deployment Examples** and **Guides** categories contained nothing but commented-out entries pointing at the deleted pages, so they would have rendered as empty `generated-index` pages — removed. Container Layer now resolves directly to **Components**, its only populated subsection.
- The commented-out `operating-scs/overview` entry was removed.

## Impact

No real content is removed and no live link or sidebar entry referenced any of these files, so the build is unaffected.

## Not included

Three orphaned pages that contain **real content** were intentionally left in place, as they likely want re-linking rather than deletion: `docs/01-getting-started/preinstall-checklist.md`, `docs/05-iam/iaas-roles.md`, and `docs/07-standards/index.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)