### PR TITLE
docs: clean up remaining orphaned pages and re-link real ones

### DIFF
--- a/docs/01-getting-started/containerization.md
+++ b/docs/01-getting-started/containerization.md
@@ -1,7 +1,0 @@
----
-sidebar: 3
----
-
-# Containerization
-
-TODO

--- a/docs/01-getting-started/overview.md
+++ b/docs/01-getting-started/overview.md
@@ -1,7 +1,0 @@
----
-sidebar: 1
----
-
-# Overview
-
-TODO

--- a/docs/01-getting-started/virtualization.md
+++ b/docs/01-getting-started/virtualization.md
@@ -1,7 +1,0 @@
----
-sidebar: 2
----
-
-# Virtualization
-
-TODO

--- a/docs/07-standards/index.md
+++ b/docs/07-standards/index.md
@@ -1,3 +1,0 @@
-# Standards
-
-TODO

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -4,6 +4,7 @@
 const sidebarsDocs = {
   docs: [
     'index',
+    'getting-started/preinstall-checklist',
     {
       type: 'category',
       label: 'IaaS Layer',
@@ -333,6 +334,7 @@ const sidebarsDocs = {
             'iam/SCS-example-setup-configuration-description'
           ]
         },
+        'iam/iaas-roles',
         'iam/intra-SCS-federation-setup-description-for-osism-doc-operations'
       ]
     },


### PR DESCRIPTION
Follow-up to #389, which removed the first batch of orphaned placeholder pages. This finishes the cleanup of the pages carried over from the `docs-page` / `scs-docs` subtree merges that were never wired into the consolidated sidebar.

## Remove remaining `TODO` stubs

Four more pages that were unreachable (no sidebar entry, no inbound links, not under any autogenerated directory) and contained only a heading plus a `TODO` marker:

- `docs/07-standards/index.md`
- `docs/01-getting-started/containerization.md`
- `docs/01-getting-started/overview.md`
- `docs/01-getting-started/virtualization.md`

## Re-link real content instead of deleting

Two orphaned pages held actual content, so they are wired into the sidebar rather than removed:

- `docs/01-getting-started/preinstall-checklist.md` — added as a top-level entry right after the landing page, as pre-installation planning material.
- `docs/05-iam/iaas-roles.md` — added under the Identity and Access Management category, alongside the federation setup page, as the reference for the IaaS-layer roles an SCS-compliant cloud offers.

## Impact

No live link or sidebar entry referenced the deleted stubs, and the two re-linked pages already existed on disk, so the build is unaffected. The sidebar module still parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)