### PR TITLE
Add a simple link to the actual instruction file

### DIFF
--- a/sidebarsUserDocs.js
+++ b/sidebarsUserDocs.js
@@ -26,6 +26,11 @@ const sidebars = {
             'application-examples/opendesk-on-scs/user-import',
             'application-examples/opendesk-on-scs/contribute'
           ]
+        },
+        {
+          type: 'link',
+          label: 'Auto-scaling GitLab Runner',
+          href: 'https://gitlab.com/alasca.cloud/infra/configuration/-/blob/develop/gitlab-runner-managers/README.md'
         }
       ]
     },


### PR DESCRIPTION
This PR adds a new application example with a link to the actual documentation. Tested locally. 