### PR TITLE
Fix calendar event modal background overflow

### DIFF
--- a/src/components/calendarModal.module.css
+++ b/src/components/calendarModal.module.css
@@ -24,6 +24,7 @@
     max-width: 100%;
     width: 500px;
     background-color: #fff;
+    overflow-y: scroll;
 }
 
 .modalTitle {


### PR DESCRIPTION
This PR fixes the missing background while scrolling long calendar event descriptions.

Before:
<img width="1305" height="843" alt="Screenshot 2026-08-11 at 13 30 02" src="https://github.com/user-attachments/assets/ad6d5f60-dc73-4d94-a704-924f5d309660" />

After:
<img width="1305" height="843" alt="Screenshot 2026-08-11 at 13 30 24" src="https://github.com/user-attachments/assets/9d22d7bd-f071-44ea-a410-0d97df789f82" />
