### PR TITLE
redirect old scope pages to new scope standards

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,12 +72,12 @@ const config = {
       {
         redirects: [
           {
-            to: '/standards/scopes/scs-0501',
-            from: '/standards/scs-compatible-iaas'
+            from: '/standards/scs-compatible-iaas',
+            to: '/standards/scopes/scs-0501'
           },
           {
-            to: '/standards/scopes/scs-0502',
-            from: '/standards/scs-compatible-kaas'
+            from: '/standards/scs-compatible-kaas',
+            to: '/standards/scopes/scs-0502'
           }
         ],
         createRedirects(existingPath) {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -71,10 +71,14 @@ const config = {
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
-          // {
-          //   to: '/community/collaboration',
-          //   from: '/community/calendar'
-          // }
+          {
+            to: '/standards/scopes/scs-0501',
+            from: '/standards/scs-compatible-iaas'
+          },
+          {
+            to: '/standards/scopes/scs-0502',
+            from: '/standards/scs-compatible-kaas'
+          }
         ],
         createRedirects(existingPath) {
           if (existingPath.includes('/community')) {


### PR DESCRIPTION
This will fix the broken links to the old scope pages (HTTP 404) by redirecting to the new scope standards. We should not have broken links, see ["Cool URIs don’t change"](https://www.w3.org/Provider/Style/URI.html) for a reasoning.

This is caused by SovereignCloudStack/standards#1199.

